### PR TITLE
Fixes #977

### DIFF
--- a/Sources/ImageCell.swift
+++ b/Sources/ImageCell.swift
@@ -30,10 +30,12 @@ public final class ImageCell: Cell<UIImage>, CellType {
         super.setup()
         
         accessoryType = .none
+        editingAccessoryView = .none
         let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 44, height: 44))
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         accessoryView = imageView
+        editingAccessoryView = imageView
     }
     
     public override func update() {
@@ -41,6 +43,7 @@ public final class ImageCell: Cell<UIImage>, CellType {
         
         selectionStyle = row.isDisabled ? .none : .default
         (accessoryView as? UIImageView)?.image = row.value
+        (editingAccessoryView as? UIImageView)?.image = row.value
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/xmartlabs/Eureka/issues/977 .

Changes proposed in this request:
* Add the selected `UIImage` to the cell's `editAccesoryView` so that it is shown even if the `tableView` is in edit mode


