### PR TITLE
More flexible Eureka dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode8.3
 env:
 - DESTINATION="OS=10.0,name=iPhone 7" SCHEME="ImageRow" SDK=iphonesimulator10.0
 

--- a/ImageRow.podspec
+++ b/ImageRow.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.requires_arc = true
   s.ios.source_files = 'Sources/**/*.{swift}'
-  s.dependency 'Eureka', '3.0'
+  s.dependency 'Eureka', '~> 3.0'
 end

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can also experiment and learn with the *ImageRow Playground* which is contai
 To install ImageRow, simply add the following line to your Podfile:
 
 ```ruby
-pod 'ImageRow', '~> 1.0'
+pod 'ImageRow', '~> 2.0'
 ```
 
 #### Carthage
@@ -99,7 +99,7 @@ pod 'ImageRow', '~> 1.0'
 To install ImageRow, simply add the following line to your Cartfile:
 
 ```ogdl
-github "EurekaCommunity/ImageRow" ~> 1.0
+github "EurekaCommunity/ImageRow" ~> 2.0
 ```
 
 ## Customization


### PR DESCRIPTION
The podspec Eureka dependency was pinned to Eureka 3.0. This change allows integration with projects using newer versions of Eureka.

This also fixes Cocoapods and Carthage installation docs.

Changes proposed in this request:
* Change podspec  Eureka dependency to `s.dependency 'Eureka', '~> 3.0'`
