### PR TITLE
Add Option to crop image and use edited image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,13 @@ github "EurekaCommunity/ImageRow" ~> 3.0
 
 ## Customization
 
-ImageRow has 2 properties to customize:
+ImageRow has 5 properties to customize:
 
 * `sourceTypes` which allows us to specify the source of the picture. It could be .PhotoLibrary, .Camera, .SavedPhotosAlbum, or any combination of the previous values since `sourceTypes` property type is `ImageRowSourceTypes` which conforms to `OptionSet`.
 * `clearAction` let's us add a clear action sheet option  and configure its style. Possible values are: `.no` or `.yes(style: UIAlertActionStyle)`. Notice that .yes value requires we pass a `UIAlertActionStyle` style.
+* `allowEditor` tells the `ImagePickerController` to use the standard system image editor after a Image is selected. Possible values are: `true` or `false`. The default value for this property is `false`.
+* `useEditedImage` tells the `ImageRow` to use the edited Image from the editor instead of the original one. Possible values are: `true` or `false`. The default value for this property is `false`.
+* `userPickerInfo` this property holds the `info` properties of the `ImagePickerController` after a edited Image is selected, this can be used to further customization or information usage of the selected image. By default this property is `nil`.
 
 To localize the Actionsheet strings just add the keys `"Take photo", "Photo Library", "Saved Photos", "Cancel", "Clear Photo"` to your Localizable.strings file
 

--- a/Sources/ImagePickerController.swift
+++ b/Sources/ImagePickerController.swift
@@ -36,14 +36,15 @@ open class ImagePickerController: UIImagePickerController, TypedRowControllerTyp
     
     open override func viewDidLoad() {
         super.viewDidLoad()
+        allowsEditing = (row as? ImageRow)?.allowEditor ?? false
         delegate = self
     }
     
     open func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
         (row as? ImageRow)?.imageURL = info[UIImagePickerControllerReferenceURL] as? URL
         
-        row.value = info[UIImagePickerControllerOriginalImage] as? UIImage
-        row.userPickerInfo = info
+        row.value = info[ (row as? ImageRow)?.useEditedImage ?? false ? UIImagePickerControllerEditedImage : UIImagePickerControllerOriginalImage] as? UIImage
+        (row as? ImageRow)?.userPickerInfo = info
         onDismissCallback?(self)
     }
     

--- a/Sources/ImagePickerController.swift
+++ b/Sources/ImagePickerController.swift
@@ -41,7 +41,9 @@ open class ImagePickerController: UIImagePickerController, TypedRowControllerTyp
     
     open func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
         (row as? ImageRow)?.imageURL = info[UIImagePickerControllerReferenceURL] as? URL
+        
         row.value = info[UIImagePickerControllerOriginalImage] as? UIImage
+        row.userPickerInfo = info
         onDismissCallback?(self)
     }
     

--- a/Sources/ImageRow.swift
+++ b/Sources/ImageRow.swift
@@ -29,8 +29,6 @@ public struct ImageRowSourceTypes: OptionSet {
     public let rawValue: Int
     public var imagePickerControllerSourceTypeRawValue: Int { return self.rawValue >> 1 }
 
-    public var userPickerInfo : [String:Any]?
-    
     public init(rawValue: Int) { self.rawValue = rawValue }
     init(_ sourceType: UIImagePickerControllerSourceType) { self.init(rawValue: 1 << sourceType.rawValue) }
 
@@ -79,11 +77,19 @@ open class _ImageRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType, ImageR
   open var imageURL: URL?
   open var clearAction = ImageClearAction.yes(style: .destructive)
   open var placeholderImage: UIImage?
+    
+  open var userPickerInfo : [String:Any]?
+  open var allowEditor : Bool
+  open var useEditedImage : Bool
 
   private var _sourceType: UIImagePickerControllerSourceType = .camera
 
   public required init(tag: String?) {
     sourceTypes = .All
+    userPickerInfo = nil
+    allowEditor = false
+    useEditedImage = false
+    
     super.init(tag: tag)
 
     presentationMode = .presentModally(controllerProvider: ControllerProvider.callback { return ImagePickerController() }, onDismiss: { [weak self] vc in

--- a/Sources/ImageRow.swift
+++ b/Sources/ImageRow.swift
@@ -29,6 +29,8 @@ public struct ImageRowSourceTypes: OptionSet {
     public let rawValue: Int
     public var imagePickerControllerSourceTypeRawValue: Int { return self.rawValue >> 1 }
 
+    public var userPickerInfo : [String:Any]?
+    
     public init(rawValue: Int) { self.rawValue = rawValue }
     init(_ sourceType: UIImagePickerControllerSourceType) { self.init(rawValue: 1 << sourceType.rawValue) }
 


### PR DESCRIPTION
I was implementing ImageRow into my project and noticed there was no way to use the editor.

I Mean, the snippet bellow allowed me to show the editor after my selection.

`row.onPresent({ (Forms, Picker) in
                    Picker.allowsEditing = true
                })`

However there was no way to use the edited Photo, or to get access to the EditInformation, because it is not possible to change de delegate on the `onPresent` callback.

So my solution was add 2 properties, allowEditor and useEditedImage.
Both are default to `false`

The former if set to `true` shows the editor after a Image Selection.
The ladder switches the property get from the callback to use the Cropped Image instead of the original.

I Also added a property called userPickerInfo, which stores The Edit information, that cannot be accessed otherwise.

I was also thinking about adding some options to customize the UIImagePickerController even further, but this is enough for now.