### PR TITLE
Reload table data after selection

### DIFF
--- a/Sources/ImageRow.swift
+++ b/Sources/ImageRow.swift
@@ -94,6 +94,7 @@ open class _ImageRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType, ImageR
 
     presentationMode = .presentModally(controllerProvider: ControllerProvider.callback { return ImagePickerController() }, onDismiss: { [weak self] vc in
       self?.select()
+      self?.cell?.formViewController()?.tableView?.reloadData()
       vc.dismiss(animated: true)
     })
 


### PR DESCRIPTION
Fixes #issue(s) . Image does not update after selection.

Changes proposed in this request:
* Following AlertRow, reload data to show image


