### PR TITLE
Fixed issues which inhibited subclassing.

### DIFF
--- a/Sources/ImagePickerController.swift
+++ b/Sources/ImagePickerController.swift
@@ -25,6 +25,16 @@
 import Eureka
 import Foundation
 
+public protocol ImagePickerProtocol: class {
+    var allowEditor: Bool { get set }
+
+    var imageURL: URL? { get set }
+
+    var useEditedImage: Bool { get set }
+
+    var userPickerInfo: [UIImagePickerController.InfoKey:Any]? { get set }
+}
+
 /// Selector Controller used to pick an image
 open class ImagePickerController: UIImagePickerController, TypedRowControllerType, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     
@@ -40,15 +50,15 @@ open class ImagePickerController: UIImagePickerController, TypedRowControllerTyp
     
     open override func viewDidLoad() {
         super.viewDidLoad()
-        allowsEditing = (row as? ImageRow)?.allowEditor ?? false
+        allowsEditing = (row as? ImagePickerProtocol)?.allowEditor ?? false
         delegate = self
     }
     
     open func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        (row as? ImageRow)?.imageURL = info[UIImagePickerController.InfoKey.referenceURL] as? URL
-        
-        row.value = info[ (row as? ImageRow)?.useEditedImage ?? false ? UIImagePickerController.InfoKey.editedImage : UIImagePickerController.InfoKey.originalImage] as? UIImage
-        (row as? ImageRow)?.userPickerInfo = info
+        (row as? ImagePickerProtocol)?.imageURL = info[UIImagePickerController.InfoKey.referenceURL] as? URL
+
+        row.value = info[ (row as? ImagePickerProtocol)?.useEditedImage ?? false ? UIImagePickerController.InfoKey.editedImage : UIImagePickerController.InfoKey.originalImage] as? UIImage
+        (row as? ImagePickerProtocol)?.userPickerInfo = info
         onDismissCallback?(self)
     }
     

--- a/Sources/ImageRow.swift
+++ b/Sources/ImageRow.swift
@@ -58,13 +58,13 @@ public enum ImageClearAction {
     case yes(style: UIAlertAction.Style)
 }
 
-protocol ImageRowProtocol {
+public protocol ImageRowProtocol {
     var placeholderImage: UIImage? { get }
 }
 
 //MARK: Row
 
-open class _ImageRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType, ImageRowProtocol where Cell: BaseCell, Cell.Value == UIImage {
+open class _ImageRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType, ImageRowProtocol, ImagePickerProtocol where Cell: BaseCell, Cell.Value == UIImage {
   public typealias PresenterRow = ImagePickerController
 
   /// Defines how the view controller will be presented, pushed, etc.


### PR DESCRIPTION
`ImageRow` and `ImageCell` cannot be directly sub-classed, due to it's final modifiers.

Therefore, sub-classing needs to be done like this:
(In this case, it is, because I need a styled cell using a XIB.)

```swift
import UIKit
import Eureka
import ImageRow

public final class AvatarCell: PushSelectorCell<UIImage> {

    @IBOutlet weak var avatar: UIImageView!

    public override func update() {
        super.update()

        accessoryType = .none
        editingAccessoryView = .none

        avatar.image = row.value ?? (row as? ImageRowProtocol)?.placeholderImage
    }
}

final class AvatarRow: _ImageRow<AvatarCell>, RowType {

    required init(tag: String?) {
        super.init(tag: tag)

        cellProvider = CellProvider<AvatarCell>(nibName: String(describing: AvatarCell.self))
    }
}
```

A non-public `ImageRowProtocol` effectively prevents that.
Additionally, `ImagePickerController` casts `row` to `ImageRow` which we can't fulfill when overriding,
Config options are therefore ignored.
To resolve this, I introduced an `ImagePickerProtocol`.

Would be great, if you could merge this, so I don't have to rely on my fork.

Thanks a lot!

Benjamin