### PR TITLE
Add support for Eureka 5.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 - brew update
 - brew outdated carthage || brew upgrade carthage
 - carthage update --platform iOS
-- gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+- gem install xcpretty --no-document --quiet
 
 script:
 - xcodebuild clean build -project ImageRow.xcodeproj -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode10.2
 env:
-- DESTINATION="OS=12.0,name=iPhone 8" SCHEME="ImageRow" SDK=iphonesimulator
+- DESTINATION="OS=12.2,name=iPhone 8" SCHEME="ImageRow" SDK=iphonesimulator
 
 before_install:
 - brew update

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "xmartlabs/Eureka" ~> 4.0
+github "xmartlabs/Eureka" ~> 5.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v7.3.1"
-github "Quick/Quick" "v1.3.2"
-github "xmartlabs/Eureka" "4.3.1"
+github "Quick/Nimble" "v8.0.1"
+github "Quick/Quick" "v2.0.0"
+github "xmartlabs/Eureka" "5.0.0"

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -176,7 +176,7 @@
 			};
 			buildConfigurationList = 28F828C71C4B714D00330CF4 /* Build configuration list for PBXProject "Example" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,

--- a/ImageRow.podspec
+++ b/ImageRow.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |s|
   s.name             = "ImageRow"
-  s.version          = "3.2.0"
+  s.version          = "4.0.0"
   s.summary          = "Eureka row that allows us to take or select a picture."
   s.homepage         = "https://github.com/EurekaCommunity/ImageRow"
   s.license          = { type: 'MIT', file: 'LICENSE' }
   s.author           = { "Xmartlabs SRL" => "swift@xmartlabs.com" }
   s.source           = { git: "https://github.com/EurekaCommunity/ImageRow.git", tag: s.version.to_s }
   s.social_media_url = 'https://twitter.com/EurekaCommunity'
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '9.3'
   s.requires_arc = true
   s.ios.source_files = 'Sources/**/*.{swift}'
-  s.dependency 'Eureka', '~> 4.3'
-  s.swift_version = "4.2"
+  s.dependency 'Eureka', '~> 5.0'
+  s.swift_version = "5.0"
 end

--- a/ImageRow.xcodeproj/project.pbxproj
+++ b/ImageRow.xcodeproj/project.pbxproj
@@ -172,17 +172,17 @@
 				TargetAttributes = {
 					28F8287C1C494B2C00330CF4 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 					};
 					28F828861C494B2C00330CF4 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
 			buildConfigurationList = 28F828771C494B2C00330CF4 /* Build configuration list for PBXProject "ImageRow" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -292,7 +292,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -344,7 +344,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -375,8 +375,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -399,8 +398,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.xmartlabs.ImageRow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -418,8 +416,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.xmartlabs.ImageRowTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -436,8 +433,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xmartlabs.ImageRowTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ You must add the **NSPhotoLibraryUsageDescription**  and **NSCameraUsageDescript
 
 ## Requirements
 
-* iOS 9.0+
-* Xcode 9.0+
-* Eureka ~> 4.0
+* iOS 9.3+
+* Xcode 10.2+
+* Eureka ~> 5.0
 
 ## Getting involved
 
@@ -89,7 +89,7 @@ You can also experiment and learn with the *ImageRow Playground* which is contai
 To install ImageRow, simply add the following line to your Podfile:
 
 ```ruby
-pod 'ImageRow', '~> 3.0'
+pod 'ImageRow', '~> 4.0'
 ```
 
 #### Carthage
@@ -99,7 +99,7 @@ pod 'ImageRow', '~> 3.0'
 To install ImageRow, simply add the following line to your Cartfile:
 
 ```ogdl
-github "EurekaCommunity/ImageRow" ~> 3.0
+github "EurekaCommunity/ImageRow" ~> 4.0
 ```
 
 ## Customization

--- a/Tests/ImageRowTests.swift
+++ b/Tests/ImageRowTests.swift
@@ -68,9 +68,9 @@ class ImageRowTests: XCTestCase {
     }
     
     func testImagePickerControllerSourceTypeRawValue() {
-        XCTAssert(UIImagePickerControllerSourceType.photoLibrary.rawValue == ImageRowSourceTypes.PhotoLibrary.imagePickerControllerSourceTypeRawValue)
-        XCTAssert(UIImagePickerControllerSourceType.camera.rawValue == ImageRowSourceTypes.Camera.imagePickerControllerSourceTypeRawValue)
-        XCTAssert(UIImagePickerControllerSourceType.savedPhotosAlbum.rawValue == ImageRowSourceTypes.SavedPhotosAlbum.imagePickerControllerSourceTypeRawValue)
+        XCTAssert(UIImagePickerController.SourceType.photoLibrary.rawValue == ImageRowSourceTypes.PhotoLibrary.imagePickerControllerSourceTypeRawValue)
+        XCTAssert(UIImagePickerController.SourceType.camera.rawValue == ImageRowSourceTypes.Camera.imagePickerControllerSourceTypeRawValue)
+        XCTAssert(UIImagePickerController.SourceType.savedPhotosAlbum.rawValue == ImageRowSourceTypes.SavedPhotosAlbum.imagePickerControllerSourceTypeRawValue)
     }
     
     func testImageRow() {


### PR DESCRIPTION
Fixes: https://github.com/EurekaCommunity/ImageRow/issues/63

Changes proposed in this request:
* Adds a requirement for Eureka 5
* Adds a requirement for iOS 9.3+
* Adds a requirement for Swift 5 (and therefore Xcode 10.2+)

There aren't any actual code changes, just some minor changes to enums used in the tests (`UIImagePickerControllerSourceType` --> `UIImagePickerController.SourceType`).

The rest of the changes were from increasing the Eureka requirement, and letting Xcode 10.2 do its thing.