### PR TITLE
Allows setting a thumbnail image

### DIFF
--- a/Sources/ImageCell.swift
+++ b/Sources/ImageCell.swift
@@ -43,7 +43,7 @@ public final class ImageCell: PushSelectorCell<UIImage> {
         super.update()
         
         selectionStyle = row.isDisabled ? .none : .default
-        (accessoryView as? UIImageView)?.image = row.value ?? (row as? ImageRowProtocol)?.placeholderImage
-        (editingAccessoryView as? UIImageView)?.image = row.value ?? (row as? ImageRowProtocol)?.placeholderImage
+        (accessoryView as? UIImageView)?.image = row.value ?? (row as? ImageRowProtocol)?.thumbnailImage ?? (row as? ImageRowProtocol)?.placeholderImage
+        (editingAccessoryView as? UIImageView)?.image = row.value ?? (row as? ImageRowProtocol)?.thumbnailImage ?? (row as? ImageRowProtocol)?.placeholderImage
     }
 }

--- a/Sources/ImageRow.swift
+++ b/Sources/ImageRow.swift
@@ -173,7 +173,8 @@ open class _ImageRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType, ImageR
 
         createOptionsForAlertController(sourceActionSheet)
 
-        if case .yes(let style) = clearAction, value != nil {
+        // if thumbnail or value is set, offer clear action
+        if case .yes(let style) = clearAction, value != nil || thumbnailImage != nil {
             let clearPhotoOption = UIAlertAction(title: NSLocalizedString("Clear Photo", comment: ""), style: style) { [weak self] _ in
                 self?.value = nil
                 self?.thumbnailImage = nil

--- a/Sources/ImageRow.swift
+++ b/Sources/ImageRow.swift
@@ -60,6 +60,7 @@ public enum ImageClearAction {
 
 public protocol ImageRowProtocol {
     var placeholderImage: UIImage? { get }
+    var thumbnailImage: UIImage? { get }
 }
 
 //MARK: Row
@@ -77,6 +78,7 @@ open class _ImageRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType, ImageR
   open var imageURL: URL?
   open var clearAction = ImageClearAction.yes(style: .destructive)
   open var placeholderImage: UIImage?
+  open var thumbnailImage: UIImage?
     
   open var userPickerInfo : [UIImagePickerController.InfoKey:Any]?
   open var allowEditor : Bool

--- a/Sources/ImageRow.swift
+++ b/Sources/ImageRow.swift
@@ -176,6 +176,7 @@ open class _ImageRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType, ImageR
         if case .yes(let style) = clearAction, value != nil {
             let clearPhotoOption = UIAlertAction(title: NSLocalizedString("Clear Photo", comment: ""), style: style) { [weak self] _ in
                 self?.value = nil
+                self?.thumbnailImage = nil
                 self?.imageURL = nil
                 self?.updateCell()
             }


### PR DESCRIPTION
I use ImageRow in a project that works with a REST API. When the object the user does edit using an Eureka form already has an image defined for the attribute associated with the ImageRow I only want to download a thumbnail from the server to show an image is already set. However I do not want to set the `value` of the ImageRow to the thumbnail image because the `value` is always considered as representing the full resolution image set by the user.

Therefore this PR introduces a new attribute `thumbnailImage` to ImageRow which allows setting a thumbnail image and does not conflict with the actual value of the ImageRow.