### PR TITLE
Fixed issue where the image on the second row will go to the left in …

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: FormViewController {
                 }
                 .cellUpdate { cell, row in
                     cell.accessoryView?.layer.cornerRadius = 17
-                    cell.accessoryView?.frame = CGRect(x: 0, y: 0, width: 34, height: 34)
+                    cell.accessoryView?.frame.size = CGSize(width: 34, height: 34)
                 }
              +++
                  Section()


### PR DESCRIPTION
…the example. This happened during cellUpdate

Fixes #issue(s) .

Changes proposed in this request:
* Change the the update on the second example row

