### PR TITLE
Fixes issue where on iOS 13, the allowEditor flag is not respected #73

### DIFF
--- a/Sources/ImagePickerController.swift
+++ b/Sources/ImagePickerController.swift
@@ -50,7 +50,6 @@ open class ImagePickerController: UIImagePickerController, TypedRowControllerTyp
     
     open override func viewDidLoad() {
         super.viewDidLoad()
-        allowsEditing = (row as? ImagePickerProtocol)?.allowEditor ?? false
         delegate = self
     }
     

--- a/Sources/ImageRow.swift
+++ b/Sources/ImageRow.swift
@@ -94,7 +94,13 @@ open class _ImageRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType, ImageR
     
     super.init(tag: tag)
 
-    presentationMode = .presentModally(controllerProvider: ControllerProvider.callback { return ImagePickerController() }, onDismiss: { [weak self] vc in
+    presentationMode = .presentModally(controllerProvider:
+        ControllerProvider.callback { [weak self] in
+            let controller = ImagePickerController()
+            controller.allowsEditing = self?.allowEditor ?? false
+            return controller
+        
+        }, onDismiss: { [weak self] vc in
       self?.select()
       vc.dismiss(animated: true)
     })


### PR DESCRIPTION
Fixes issue where on iOS 13, the allowEditor flag is not respected

Changes proposed in this request:
* Move the setting of `allowEditor` to where the ImagePickerController is created, rather than in viewDidLoad.  It seems to be that in iOS 13, viewDidLoad is too late to set this param.

Tested on iOS 13 & iOS 12


