### PR TITLE
Move userPickerInfo set before value set

### DIFF
--- a/Sources/ImagePickerController.swift
+++ b/Sources/ImagePickerController.swift
@@ -55,9 +55,9 @@ open class ImagePickerController: UIImagePickerController, TypedRowControllerTyp
     
     open func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         (row as? ImagePickerProtocol)?.imageURL = info[UIImagePickerController.InfoKey.referenceURL] as? URL
-
-        row.value = info[ (row as? ImagePickerProtocol)?.useEditedImage ?? false ? UIImagePickerController.InfoKey.editedImage : UIImagePickerController.InfoKey.originalImage] as? UIImage
         (row as? ImagePickerProtocol)?.userPickerInfo = info
+        row.value = info[ (row as? ImagePickerProtocol)?.useEditedImage ?? false ? UIImagePickerController.InfoKey.editedImage : UIImagePickerController.InfoKey.originalImage] as? UIImage
+        
         onDismissCallback?(self)
     }
     


### PR DESCRIPTION
Set the userPickerInfo property on the ImageRow before the value is set so that the userPickerInfo is available in the onChange event.


