### PR TITLE
Fixes for #83 and #82

### DIFF
--- a/Sources/ImagePickerController.swift
+++ b/Sources/ImagePickerController.swift
@@ -56,8 +56,16 @@ open class ImagePickerController: UIImagePickerController, TypedRowControllerTyp
     
     open func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         (row as? ImagePickerProtocol)?.imageURL = info[UIImagePickerController.InfoKey.referenceURL] as? URL
+
+        row.value = info[UIImagePickerController.InfoKey.originalImage] as? UIImage
+        
+        let editedImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage
+
+        if(((row as? ImagePickerProtocol)?.useEditedImage ?? false) && editedImage != nil) {
+            row.value = editedImage
+        }
+        
         (row as? ImagePickerProtocol)?.userPickerInfo = info
-        row.value = info[ (row as? ImagePickerProtocol)?.useEditedImage ?? false ? UIImagePickerController.InfoKey.editedImage : UIImagePickerController.InfoKey.originalImage] as? UIImage
         
         onDismissCallback?(self)
     }

--- a/Sources/ImagePickerController.swift
+++ b/Sources/ImagePickerController.swift
@@ -57,16 +57,16 @@ open class ImagePickerController: UIImagePickerController, TypedRowControllerTyp
     open func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         (row as? ImagePickerProtocol)?.imageURL = info[UIImagePickerController.InfoKey.referenceURL] as? URL
 
-        row.value = info[UIImagePickerController.InfoKey.originalImage] as? UIImage
+        var finalImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage
         
         let editedImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage
 
         if(((row as? ImagePickerProtocol)?.useEditedImage ?? false) && editedImage != nil) {
-            row.value = editedImage
+            finalImage = editedImage
         }
         
         (row as? ImagePickerProtocol)?.userPickerInfo = info
-        
+        row.value = finalImage
         onDismissCallback?(self)
     }
     


### PR DESCRIPTION
Setting the `useEditedImage` flag to True makes it use the Edited image even when it is `nil`.

This PR makes changes to `ImagePickerController.swift` in order to ensure to use the edited image only if it's not nil, even if useEdited Image is set to true. This should clear issues where the row would be blank after picking an image from the library.

This feature was added on PR #36, however this issue only started showing if self on iOS 13. Apps using the iOS 13 or earlier SDK, would have an issue where the image cropper would now show up after picking an image from the library. Apple changed this behaviour back to the old one on the iOS 14 SDK.